### PR TITLE
Fix | Example: Imports

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,8 @@
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-scripts": "1.1.1",
-    "styled-components": "^4.0.2"
+    "styled-components": "^4.0.2",
+    "styled-bootstrap-grid": "link:../"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import {
   Container, Row, Col, BaseCSS,
-} from './styled-bootstrap-grid';
+} from 'styled-bootstrap-grid';
 
 const TitleRow = styled(Row)`
   margin-bottom: 10px;

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ThemeProvider } from 'styled-components';
-import { GridThemeProvider } from './styled-bootstrap-grid';
+import { GridThemeProvider } from 'styled-bootstrap-grid';
 
 import './index.css';
 import App from './App';


### PR DESCRIPTION
Use Yarn to properly import local`styled-bootstrap-grid` ~ fixes #31