### PR TITLE
[WIP] Components use react's forwardRef API

### DIFF
--- a/dist/Col.js
+++ b/dist/Col.js
@@ -20,7 +20,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var MyCol = function MyCol(props) {
+var MyCol = _react2.default.forwardRef(function (props, ref) {
   var col = props.col,
       offset = props.offset,
       auto = props.auto,
@@ -280,10 +280,10 @@ var MyCol = function MyCol(props) {
 
   return _react2.default.createElement(
     _styled.Col,
-    allProps,
+    _extends({ ref: ref }, allProps),
     children
   );
-};
+});
 
 var stringOrNumberReactPropType = _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]);
 

--- a/dist/Container.js
+++ b/dist/Container.js
@@ -20,7 +20,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var container = function container(props) {
+var container = _react2.default.forwardRef(function (props, ref) {
   var fluid = props.fluid,
       children = props.children,
       otherProps = _objectWithoutProperties(props, ['fluid', 'children']);
@@ -28,16 +28,16 @@ var container = function container(props) {
   if (fluid) {
     return _react2.default.createElement(
       _styled.ContainerFluid,
-      _extends({ 'data-name': 'container-fluid' }, otherProps),
+      _extends({ 'data-name': 'container-fluid', ref: ref }, otherProps),
       children
     );
   }
   return _react2.default.createElement(
     _styled.Container,
-    _extends({ 'data-name': 'container' }, otherProps),
+    _extends({ 'data-name': 'container', ref: ref }, otherProps),
     children
   );
-};
+});
 
 container.propTypes = {
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node, _propTypes2.default.string]).isRequired,

--- a/dist/Row.js
+++ b/dist/Row.js
@@ -20,7 +20,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var row = function row(props) {
+var row = _react2.default.forwardRef(function (props, ref) {
   var children = props.children,
       alignItems = props.alignItems,
       smAlignItems = props.smAlignItems,
@@ -81,11 +81,12 @@ var row = function row(props) {
       mdJustifyContent: mdJustifyContent,
       lgJustifyContent: lgJustifyContent,
       xlJustifyContent: xlJustifyContent,
-      'data-name': dataName
+      'data-name': dataName,
+      ref: ref
     }, otherProps),
     children
   );
-};
+});
 
 row.propTypes = {
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node, _propTypes2.default.string]).isRequired,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-bootstrap-grid",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "bootstrap grid system using styled components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Col.jsx
+++ b/src/Col.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Col } from './styled';
 
-const MyCol = (props) => {
+const MyCol = React.forwardRef((props, ref) => {
   const {
     col,
     offset,
@@ -265,11 +265,11 @@ const MyCol = (props) => {
   };
 
   return (
-    <Col {...allProps}>
+    <Col ref={ref} {...allProps}>
       {children}
     </Col>
   );
-};
+});
 
 const stringOrNumberReactPropType = PropTypes.oneOfType([
   PropTypes.string,

--- a/src/Container.jsx
+++ b/src/Container.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Container, ContainerFluid } from './styled';
 
-const container = (props) => {
+const container = React.forwardRef((props, ref) => {
   const {
     fluid,
     children,
@@ -11,10 +11,10 @@ const container = (props) => {
   } = props;
 
   if (fluid) {
-    return <ContainerFluid data-name="container-fluid" {...otherProps}>{children}</ContainerFluid>;
+    return <ContainerFluid data-name="container-fluid" ref={ref} {...otherProps}>{children}</ContainerFluid>;
   }
-  return <Container data-name="container" {...otherProps}>{children}</Container>;
-};
+  return <Container data-name="container" ref={ref} {...otherProps}>{children}</Container>;
+});
 
 container.propTypes = {
   children: PropTypes.oneOfType([

--- a/src/Row.jsx
+++ b/src/Row.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Row } from './styled';
 
-const row = (props) => {
+const row = React.forwardRef((props, ref) => {
   const {
     children,
     alignItems,
@@ -66,12 +66,13 @@ const row = (props) => {
       lgJustifyContent={lgJustifyContent}
       xlJustifyContent={xlJustifyContent}
       data-name={dataName}
+      ref={ref}
       {...otherProps}
     >
       {children}
     </Row>
   );
-};
+});
 
 row.propTypes = {
   children: PropTypes.oneOfType([


### PR DESCRIPTION
Previously, ref's weren't being forwarded down to styled-components and never reached the actual DOM node.