### PR TITLE
Bumped version up to 2.0.0 as recommended in react docs.

### DIFF
--- a/dist/Col.js
+++ b/dist/Col.js
@@ -20,7 +20,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var MyCol = _react2.default.forwardRef(function (props, ref) {
+var MyCol = function MyCol(props, ref) {
   var col = props.col,
       offset = props.offset,
       auto = props.auto,
@@ -283,7 +283,7 @@ var MyCol = _react2.default.forwardRef(function (props, ref) {
     _extends({ ref: ref }, allProps),
     children
   );
-});
+};
 
 var stringOrNumberReactPropType = _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]);
 
@@ -362,4 +362,4 @@ MyCol.defaultProps = {
   xlOrder: null
 };
 
-exports.default = MyCol;
+exports.default = _react2.default.forwardRef(MyCol);

--- a/dist/Container.js
+++ b/dist/Container.js
@@ -20,7 +20,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var container = _react2.default.forwardRef(function (props, ref) {
+var container = function container(props, ref) {
   var fluid = props.fluid,
       children = props.children,
       otherProps = _objectWithoutProperties(props, ['fluid', 'children']);
@@ -37,7 +37,7 @@ var container = _react2.default.forwardRef(function (props, ref) {
     _extends({ 'data-name': 'container', ref: ref }, otherProps),
     children
   );
-});
+};
 
 container.propTypes = {
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node, _propTypes2.default.string]).isRequired,
@@ -48,4 +48,4 @@ container.defaultProps = {
   fluid: false
 };
 
-exports.default = container;
+exports.default = _react2.default.forwardRef(container);

--- a/dist/Row.js
+++ b/dist/Row.js
@@ -20,7 +20,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var row = _react2.default.forwardRef(function (props, ref) {
+var row = function row(props, ref) {
   var children = props.children,
       alignItems = props.alignItems,
       smAlignItems = props.smAlignItems,
@@ -86,7 +86,7 @@ var row = _react2.default.forwardRef(function (props, ref) {
     }, otherProps),
     children
   );
-});
+};
 
 row.propTypes = {
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node, _propTypes2.default.string]).isRequired,
@@ -115,4 +115,4 @@ row.defaultProps = {
   xlJustifyContent: null
 };
 
-exports.default = row;
+exports.default = _react2.default.forwardRef(row);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-bootstrap-grid",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "bootstrap grid system using styled components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Col.jsx
+++ b/src/Col.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Col } from './styled';
 
-const MyCol = React.forwardRef((props, ref) => {
+const MyCol = (props, ref) => {
   const {
     col,
     offset,
@@ -269,7 +269,7 @@ const MyCol = React.forwardRef((props, ref) => {
       {children}
     </Col>
   );
-});
+};
 
 const stringOrNumberReactPropType = PropTypes.oneOfType([
   PropTypes.string,
@@ -359,4 +359,4 @@ MyCol.defaultProps = {
   xlOrder: null,
 };
 
-export default MyCol;
+export default React.forwardRef(MyCol);

--- a/src/Container.jsx
+++ b/src/Container.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Container, ContainerFluid } from './styled';
 
-const container = React.forwardRef((props, ref) => {
+const container = (props, ref) => {
   const {
     fluid,
     children,
@@ -14,7 +14,7 @@ const container = React.forwardRef((props, ref) => {
     return <ContainerFluid data-name="container-fluid" ref={ref} {...otherProps}>{children}</ContainerFluid>;
   }
   return <Container data-name="container" ref={ref} {...otherProps}>{children}</Container>;
-});
+};
 
 container.propTypes = {
   children: PropTypes.oneOfType([
@@ -29,4 +29,4 @@ container.defaultProps = {
   fluid: false,
 };
 
-export default container;
+export default React.forwardRef(container);

--- a/src/Row.jsx
+++ b/src/Row.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Row } from './styled';
 
-const row = React.forwardRef((props, ref) => {
+const row = (props, ref) => {
   const {
     children,
     alignItems,
@@ -72,7 +72,7 @@ const row = React.forwardRef((props, ref) => {
       {children}
     </Row>
   );
-});
+};
 
 row.propTypes = {
   children: PropTypes.oneOfType([
@@ -106,4 +106,4 @@ row.defaultProps = {
   xlJustifyContent: null,
 };
 
-export default row;
+export default React.forwardRef(row);


### PR DESCRIPTION
According to [react docs](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers):

> When you start using forwardRef in a component library, you should treat it as a breaking change and release a new major version of your library

I also found a very strange behaviour when using `React.forwardRef()` with styled-components `.attrs()`: props will be empty in component when doing this:

```
const StyledCol = styled(Col).attrs({
    xs: 12,
    sm: 6
})`...`

...

render() {
    return <StyledCol />;
}
```

but props will be ok when doing this:

```
const StyledCol = styled(Col)`...`

...

render() {
    return <StyledCol xs={12} sm={6} />;
}
```
