### PR TITLE
Fixed passing react component straight to forwardRef()

### DIFF
--- a/dist/Col.js
+++ b/dist/Col.js
@@ -20,7 +20,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var MyCol = function MyCol(props, ref) {
+var MyCol = function MyCol(props) {
   var col = props.col,
       offset = props.offset,
       auto = props.auto,
@@ -63,7 +63,8 @@ var MyCol = function MyCol(props, ref) {
       hiddenXlDown = props.hiddenXlDown,
       noGutter = props.noGutter,
       children = props.children,
-      otherProps = _objectWithoutProperties(props, ['col', 'offset', 'auto', 'alignSelf', 'order', 'xs', 'xsOffset', 'xsAuto', 'xsAlignSelf', 'xsOrder', 'hiddenXsUp', 'hiddenXsDown', 'sm', 'smOffset', 'smAuto', 'smAlignSelf', 'smOrder', 'hiddenSmUp', 'hiddenSmDown', 'md', 'mdOffset', 'mdAuto', 'mdAlignSelf', 'mdOrder', 'hiddenMdUp', 'hiddenMdDown', 'lg', 'lgOffset', 'lgAuto', 'lgAlignSelf', 'lgOrder', 'hiddenLgUp', 'hiddenLgDown', 'xl', 'xlOffset', 'xlAuto', 'xlAlignSelf', 'xlOrder', 'hiddenXlUp', 'hiddenXlDown', 'noGutter', 'children']);
+      forwardedRef = props.forwardedRef,
+      otherProps = _objectWithoutProperties(props, ['col', 'offset', 'auto', 'alignSelf', 'order', 'xs', 'xsOffset', 'xsAuto', 'xsAlignSelf', 'xsOrder', 'hiddenXsUp', 'hiddenXsDown', 'sm', 'smOffset', 'smAuto', 'smAlignSelf', 'smOrder', 'hiddenSmUp', 'hiddenSmDown', 'md', 'mdOffset', 'mdAuto', 'mdAlignSelf', 'mdOrder', 'hiddenMdUp', 'hiddenMdDown', 'lg', 'lgOffset', 'lgAuto', 'lgAlignSelf', 'lgOrder', 'hiddenLgUp', 'hiddenLgDown', 'xl', 'xlOffset', 'xlAuto', 'xlAlignSelf', 'xlOrder', 'hiddenXlUp', 'hiddenXlDown', 'noGutter', 'children', 'forwardedRef']);
 
   var dataName = '';
   if (col) {
@@ -280,7 +281,7 @@ var MyCol = function MyCol(props, ref) {
 
   return _react2.default.createElement(
     _styled.Col,
-    _extends({ ref: ref }, allProps),
+    _extends({ ref: forwardedRef }, allProps),
     children
   );
 };
@@ -362,4 +363,6 @@ MyCol.defaultProps = {
   xlOrder: null
 };
 
-exports.default = _react2.default.forwardRef(MyCol);
+exports.default = _react2.default.forwardRef(function (props, ref) {
+  return _react2.default.createElement(MyCol, _extends({ forwardedRef: ref }, props));
+});

--- a/dist/Container.js
+++ b/dist/Container.js
@@ -20,32 +20,35 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var container = function container(props, ref) {
+var MyContainer = function MyContainer(props) {
   var fluid = props.fluid,
       children = props.children,
-      otherProps = _objectWithoutProperties(props, ['fluid', 'children']);
+      forwardedRef = props.forwardedRef,
+      otherProps = _objectWithoutProperties(props, ['fluid', 'children', 'forwardedRef']);
 
   if (fluid) {
     return _react2.default.createElement(
       _styled.ContainerFluid,
-      _extends({ 'data-name': 'container-fluid', ref: ref }, otherProps),
+      _extends({ 'data-name': 'container-fluid', ref: forwardedRef }, otherProps),
       children
     );
   }
   return _react2.default.createElement(
     _styled.Container,
-    _extends({ 'data-name': 'container', ref: ref }, otherProps),
+    _extends({ 'data-name': 'container', ref: forwardedRef }, otherProps),
     children
   );
 };
 
-container.propTypes = {
+MyContainer.propTypes = {
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node, _propTypes2.default.string]).isRequired,
   fluid: _propTypes2.default.bool
 };
 
-container.defaultProps = {
+MyContainer.defaultProps = {
   fluid: false
 };
 
-exports.default = _react2.default.forwardRef(container);
+exports.default = _react2.default.forwardRef(function (props, ref) {
+  return _react2.default.createElement(MyContainer, _extends({ forwardedRef: ref }, props));
+});

--- a/dist/Row.js
+++ b/dist/Row.js
@@ -20,8 +20,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var row = function row(props, ref) {
-  var children = props.children,
+var MyRow = function MyRow(props) {
+  var forwardedRef = props.forwardedRef,
+      children = props.children,
       alignItems = props.alignItems,
       smAlignItems = props.smAlignItems,
       mdAlignItems = props.mdAlignItems,
@@ -32,7 +33,7 @@ var row = function row(props, ref) {
       mdJustifyContent = props.mdJustifyContent,
       lgJustifyContent = props.lgJustifyContent,
       xlJustifyContent = props.xlJustifyContent,
-      otherProps = _objectWithoutProperties(props, ['children', 'alignItems', 'smAlignItems', 'mdAlignItems', 'lgAlignItems', 'xlAlignItems', 'justifyContent', 'smJustifyContent', 'mdJustifyContent', 'lgJustifyContent', 'xlJustifyContent']);
+      otherProps = _objectWithoutProperties(props, ['forwardedRef', 'children', 'alignItems', 'smAlignItems', 'mdAlignItems', 'lgAlignItems', 'xlAlignItems', 'justifyContent', 'smJustifyContent', 'mdJustifyContent', 'lgJustifyContent', 'xlJustifyContent']);
 
   var dataName = 'row';
 
@@ -82,13 +83,13 @@ var row = function row(props, ref) {
       lgJustifyContent: lgJustifyContent,
       xlJustifyContent: xlJustifyContent,
       'data-name': dataName,
-      ref: ref
+      ref: forwardedRef
     }, otherProps),
     children
   );
 };
 
-row.propTypes = {
+MyRow.propTypes = {
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node, _propTypes2.default.string]).isRequired,
   alignItems: _propTypes2.default.string,
   smAlignItems: _propTypes2.default.string,
@@ -102,7 +103,7 @@ row.propTypes = {
   xlJustifyContent: _propTypes2.default.string
 };
 
-row.defaultProps = {
+MyRow.defaultProps = {
   alignItems: null,
   smAlignItems: null,
   mdAlignItems: null,
@@ -115,4 +116,6 @@ row.defaultProps = {
   xlJustifyContent: null
 };
 
-exports.default = _react2.default.forwardRef(row);
+exports.default = _react2.default.forwardRef(function (props, ref) {
+  return _react2.default.createElement(MyRow, _extends({ forwardedRef: ref }, props));
+});

--- a/src/Col.jsx
+++ b/src/Col.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Col } from './styled';
 
-const MyCol = (props, ref) => {
+const MyCol = (props) => {
   const {
     col,
     offset,
@@ -47,6 +47,7 @@ const MyCol = (props, ref) => {
     hiddenXlDown,
     noGutter,
     children,
+    forwardedRef,
     ...otherProps
   } = props;
 
@@ -265,7 +266,7 @@ const MyCol = (props, ref) => {
   };
 
   return (
-    <Col ref={ref} {...allProps}>
+    <Col ref={forwardedRef} {...allProps}>
       {children}
     </Col>
   );
@@ -359,4 +360,4 @@ MyCol.defaultProps = {
   xlOrder: null,
 };
 
-export default React.forwardRef(MyCol);
+export default React.forwardRef((props, ref) => <MyCol forwardedRef={ref} {...props}/>);

--- a/src/Container.jsx
+++ b/src/Container.jsx
@@ -3,20 +3,21 @@ import PropTypes from 'prop-types';
 
 import { Container, ContainerFluid } from './styled';
 
-const container = (props, ref) => {
+const MyContainer = (props) => {
   const {
     fluid,
     children,
+    forwardedRef,
     ...otherProps
   } = props;
 
   if (fluid) {
-    return <ContainerFluid data-name="container-fluid" ref={ref} {...otherProps}>{children}</ContainerFluid>;
+    return <ContainerFluid data-name="container-fluid" ref={forwardedRef} {...otherProps}>{children}</ContainerFluid>;
   }
-  return <Container data-name="container" ref={ref} {...otherProps}>{children}</Container>;
+  return <Container data-name="container" ref={forwardedRef} {...otherProps}>{children}</Container>;
 };
 
-container.propTypes = {
+MyContainer.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
@@ -25,8 +26,8 @@ container.propTypes = {
   fluid: PropTypes.bool,
 };
 
-container.defaultProps = {
+MyContainer.defaultProps = {
   fluid: false,
 };
 
-export default React.forwardRef(container);
+export default React.forwardRef((props, ref) => <MyContainer forwardedRef={ref} {...props} />);

--- a/src/Row.jsx
+++ b/src/Row.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 
 import { Row } from './styled';
 
-const row = (props, ref) => {
+const MyRow = (props) => {
   const {
+    forwardedRef,
     children,
     alignItems,
     smAlignItems,
@@ -66,7 +67,7 @@ const row = (props, ref) => {
       lgJustifyContent={lgJustifyContent}
       xlJustifyContent={xlJustifyContent}
       data-name={dataName}
-      ref={ref}
+      ref={forwardedRef}
       {...otherProps}
     >
       {children}
@@ -74,7 +75,7 @@ const row = (props, ref) => {
   );
 };
 
-row.propTypes = {
+MyRow.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
@@ -93,7 +94,7 @@ row.propTypes = {
 };
 
 
-row.defaultProps = {
+MyRow.defaultProps = {
   alignItems: null,
   smAlignItems: null,
   mdAlignItems: null,
@@ -106,4 +107,4 @@ row.defaultProps = {
   xlJustifyContent: null,
 };
 
-export default React.forwardRef(row);
+export default React.forwardRef((props, ref) => <MyRow forwardedRef={ref} {...props} />);


### PR DESCRIPTION
This PR fixes a warning in console:
```
Warning: forwardRef render functions do not support propTypes or defaultProps. Did you accidentally pass a React component?