### PR TITLE
Fixed an issue where setting offset to 0 would not apply the CSS

### DIFF
--- a/src/components/Col/Col.tsx
+++ b/src/components/Col/Col.tsx
@@ -28,13 +28,13 @@ export default styled.div.attrs<ColProps>(props => ({
   ${p => p.noGutter && css.noGutter}
 
   ${p => p.col && css.col[p.col === true ? 'true' : p.col]}
-  ${p => p.offset && css.offset[p.offset]}
+  ${p => typeof p.offset !== 'undefined' && css.offset[p.offset]}
   ${p => p.auto && css.col.auto}
   ${p => p.alignSelf && css.alignSelf[p.alignSelf]}
   ${p => p.order && css.order[p.order]}
 
   ${p => p.xs && media.xs`${css.col[p.xs === true ? 'true' : p.xs]}`}
-  ${p => p.xsOffset && isNumber(p.xsOffset) && media.xs`${css.offset[p.xsOffset]}`}
+  ${p => typeof p.xsOffset !== 'undefined' && isNumber(p.xsOffset) && media.xs`${css.offset[p.xsOffset]}`}
   ${p => p.xsAuto && media.xs`${css.col.auto}`}
   ${p => p.xsAlignSelf && media.xs`${css.alignSelf[p.xsAlignSelf]}`}
   ${p => p.xsOrder && media.xs`${css.order[p.xsOrder]}`}
@@ -42,7 +42,7 @@ export default styled.div.attrs<ColProps>(props => ({
   ${p => p.hiddenXsUp && media.min.xs`${css.display.none}`}
 
   ${p => p.sm && media.sm`${css.col[p.sm === true ? 'true' : p.sm]}`}
-  ${p => p.smOffset && isNumber(p.smOffset) && media.sm`${css.offset[p.smOffset]}`}
+  ${p => typeof p.smOffset !== 'undefined' && isNumber(p.smOffset) && media.sm`${css.offset[p.smOffset]}`}
   ${p => p.smAuto && media.sm`${css.col.auto}`}
   ${p => p.smAlignSelf && media.sm`${css.alignSelf[p.smAlignSelf]}`}
   ${p => p.smOrder && media.sm`${css.order[p.smOrder]}`}
@@ -50,7 +50,7 @@ export default styled.div.attrs<ColProps>(props => ({
   ${p => p.hiddenSmUp && media.min.sm`${css.display.none}`}
 
   ${p => p.md && media.md`${css.col[p.md === true ? 'true' : p.md]}`}
-  ${p => p.mdOffset && isNumber(p.mdOffset) && media.md`${css.offset[p.mdOffset]}`}
+  ${p => typeof p.mdOffset !== 'undefined' && isNumber(p.mdOffset) && media.md`${css.offset[p.mdOffset]}`}
   ${p => p.mdAuto && media.md`${css.col.auto}`}
   ${p => p.mdAlignSelf && media.md`${css.alignSelf[p.mdAlignSelf]}`}
   ${p => p.mdOrder && media.md`${css.order[p.mdOrder]}`}
@@ -58,7 +58,7 @@ export default styled.div.attrs<ColProps>(props => ({
   ${p => p.hiddenMdUp && media.min.md`${css.display.none}`}
 
   ${p => p.lg && media.lg`${css.col[p.lg === true ? 'true' : p.lg]}`}
-  ${p => p.lgOffset && isNumber(p.lgOffset) && media.lg`${css.offset[p.lgOffset]}`}
+  ${p => typeof p.lgOffset !== 'undefined' && isNumber(p.lgOffset) && media.lg`${css.offset[p.lgOffset]}`}
   ${p => p.lgAuto && media.lg`${css.col.auto}`}
   ${p => p.lgAlignSelf && media.lg`${css.alignSelf[p.lgAlignSelf]}`}
   ${p => p.lgOrder && media.lg`${css.order[p.lgOrder]}`}
@@ -66,7 +66,7 @@ export default styled.div.attrs<ColProps>(props => ({
   ${p => p.hiddenLgUp && media.min.lg`${css.display.none}`}
 
   ${p => p.xl && media.xl`${css.col[p.xl === true ? 'true' : p.xl]}`}
-  ${p => p.xlOffset && isNumber(p.xlOffset) && media.xl`${css.offset[p.xlOffset]}`}
+  ${p => typeof p.xlOffset !== 'undefined' && isNumber(p.xlOffset) && media.xl`${css.offset[p.xlOffset]}`}
   ${p => p.xlAuto && media.xl`${css.col.auto}`}
   ${p => p.xlAlignSelf && media.xl`${css.alignSelf[p.xlAlignSelf]}`}
   ${p => p.xlOrder && media.xl`${css.order[p.xlOrder]}`}


### PR DESCRIPTION
Setting an offset of 0 on a larger breakpoint, than an already defined offset on a lower breakpoint, would not be applied because of the way `Col.tsx` checked the value.

The example below would cause the offset for the large breakpoint to also be 1.

```
<Container>
  <Row>
    <Col
      sm={10}
      smOffset={1}
      lg={6}
      lgOffset={0}
    />
  </Row>
</Container>
```

This PR changes the checks to `typeof p.offset !== 'undefined'` which also allows 0 values to be accepted.