### PR TITLE
Add children as prop to gridThemeProvider

### DIFF
--- a/src/components/ThemeProvider/types.ts
+++ b/src/components/ThemeProvider/types.ts
@@ -19,6 +19,7 @@ interface GridTheme {
 
 export interface ThemeProps {
   gridTheme?: GridTheme;
+  children: React.ReactNode;
 }
 
 export type DefaultContainerMaxWidth = { [K in MediaAliases]: number };


### PR DESCRIPTION
Hi @dragma, I'm having trouble using the `gridThemeProvider` in combination with TS. It does not expect any children as props, but if I use it as a self-closing component (`<GridThemeProvider theme={gridTheme} />`) the styles are not getting applied. This PR should fix that!