### PR TITLE
Add children to gridThemeProvider props

### DIFF
--- a/src/components/ThemeProvider/types.ts
+++ b/src/components/ThemeProvider/types.ts
@@ -19,7 +19,7 @@ interface GridTheme {
 
 export interface ThemeProps {
   gridTheme?: GridTheme;
-  children: React.ReactNode;
+  children: React.ReactChild;
 }
 
 export type DefaultContainerMaxWidth = { [K in MediaAliases]: number };


### PR DESCRIPTION
Using the correct type of children (`React.ReactChildren` instead of the incorrect `React.ReactNode`).

Should fix #54 