### PR TITLE
Extend Theme interface with DefaultTheme

### DIFF
--- a/src/components/ThemeProvider/types.ts
+++ b/src/components/ThemeProvider/types.ts
@@ -1,4 +1,5 @@
 import { MediaAliases, Media } from '../../media/types';
+import { DefaultTheme } from 'styled-components';
 
 export type Breakpoints = { [key in Media]: number };
 export type PartialBreakpoints = Partial<Breakpoints>;
@@ -37,6 +38,6 @@ export interface StyledBootstrapGrid extends GridTheme {
   getGridColumns: any;
 }
 
-export interface Theme {
+export interface Theme extends DefaultTheme {
   styledBootstrapGrid: StyledBootstrapGrid;
 }


### PR DESCRIPTION
Add typecheck to theme types `styled-component` allows you to extend. 


In addition, it would be nice if I could annotate custom props but I have 2 weeks of experience with TS so can't accomplish that

```ts
type VisibleProps = {
	sm?: boolean;
};

const VisibilityContainer = styled.div<VisibleProps>`
	${media.sm`
		display: ${(props) => (props.sm ? "block" : "none")}; // Error: TS2339: Property 'sm' does not exist on type 'ThemeProps '.
	`}
`;
```